### PR TITLE
Change the LDFLAGS after object files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -25,7 +25,7 @@ EXECUTABLE=envelope
 all: $(SOURCES) $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) -o $@
+	$(CC) $(OBJECTS) $(LDFLAGS) -o $@
 
 .c.o:
 	$(CC) $(CFLAGS) $< -c -o $@


### PR DESCRIPTION
I was getting link errors on UBUNTU 14.04 with gcc 4.9 due to libraries coming before object files.